### PR TITLE
refactor: child routes skipping support for parent failure(RDCC-2908)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -341,8 +341,8 @@ dependencies {
     }
 
     testCompile group: 'com.h2database', name: 'h2'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
-    testCompile group: 'org.mockito', name: 'mockito-inline', version: '3.1.0'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.4.6'
+    testCompile group: 'org.mockito', name: 'mockito-inline', version: '3.4.6'
     testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
     testCompile group: 'org.springframework.batch', name: 'spring-batch-test', version: '4.2.4.RELEASE'

--- a/src/main/java/uk/gov/hmcts/reform/data/ingestion/camel/processor/ParentStateCheckProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/data/ingestion/camel/processor/ParentStateCheckProcessor.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.data.ingestion.camel.processor;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.data.ingestion.camel.route.beans.FileStatus;
+import uk.gov.hmcts.reform.data.ingestion.camel.route.beans.RouteProperties;
+import uk.gov.hmcts.reform.data.ingestion.camel.util.DataLoadUtil;
+
+import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.FAILURE;
+import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.IS_PARENT_FAILED;
+import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.ROUTE_DETAILS;
+
+@Component
+public class ParentStateCheckProcessor implements Processor {
+
+    @Override
+    public void process(Exchange exchange) {
+
+        RouteProperties routeProperties = (RouteProperties) exchange.getIn()
+            .getHeader(ROUTE_DETAILS);
+        if (routeProperties.isParentFailureEnabled()) {
+            String parentFileName = routeProperties.getParentFileName();
+            FileStatus fileStatus = DataLoadUtil.getFileDetails(exchange.getContext(), parentFileName);
+            if (FAILURE.equalsIgnoreCase(fileStatus.getAuditStatus())) {
+                exchange.getMessage().setHeader(IS_PARENT_FAILED, true);
+                return;
+            }
+        }
+        exchange.getMessage().setHeader(IS_PARENT_FAILED, false);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/data/ingestion/camel/route/DataLoadRoute.java
+++ b/src/main/java/uk/gov/hmcts/reform/data/ingestion/camel/route/DataLoadRoute.java
@@ -9,6 +9,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.dataformat.BindyType;
 import org.apache.camel.model.language.SimpleExpression;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.apache.commons.lang.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.reform.data.ingestion.camel.processor.ExceptionProcessor;
 import uk.gov.hmcts.reform.data.ingestion.camel.processor.FileReadProcessor;
 import uk.gov.hmcts.reform.data.ingestion.camel.processor.FileResponseProcessor;
 import uk.gov.hmcts.reform.data.ingestion.camel.processor.HeaderValidationProcessor;
+import uk.gov.hmcts.reform.data.ingestion.camel.processor.ParentStateCheckProcessor;
 import uk.gov.hmcts.reform.data.ingestion.camel.route.beans.RouteProperties;
 import uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants;
 
@@ -32,6 +34,7 @@ import static org.apache.commons.lang.WordUtils.uncapitalize;
 import static org.apache.logging.log4j.util.Strings.isBlank;
 import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.DIRECT_ROUTE;
 import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.IS_FILE_STALE;
+import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.IS_PARENT_FAILED;
 import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.MAPPING_METHOD;
 import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.TRUNCATE_ROUTE_PREFIX;
 
@@ -74,6 +77,9 @@ public class DataLoadRoute {
 
     @Autowired
     DataSource dataSource;
+
+    @Autowired
+    ParentStateCheckProcessor parentStateCheckProcessor;
 
     @Transactional("txManager")
     public void startRoute(String startRoute, List<String> routesToExecute) throws FailedToCreateRouteException {
@@ -139,12 +145,17 @@ public class DataLoadRoute {
                                 .transacted()
                                 .policy(springTransactionPolicyNew)
                                 .setHeader(MappingConstants.ROUTE_DETAILS, () -> route)
+                                //checks parent failure status & set header
+                                .process(parentStateCheckProcessor)
+                                .choice()
+                                .when(header(IS_PARENT_FAILED).isEqualTo(false))
                                 .setProperty(MappingConstants.BLOBPATH, exp)
                                 .process(fileReadProcessor)
                                 .choice()
                                 .when(header(IS_FILE_STALE).isEqualTo(false))
                                 .to(route.getTruncateSql())
                                 .to(DIRECT_ROUTE + route.getRouteName())
+                                .endChoice()
                                 .endChoice()
                                 .end();
                         }
@@ -201,7 +212,7 @@ public class DataLoadRoute {
             properties.setCsvHeadersExpected(environment.getProperty(
                 MappingConstants.ROUTE + "." + routeName + "." + MappingConstants.CSV_HEADERS_EXPECTED));
             String isHeaderValidationEnabled = environment.getProperty(
-                    MappingConstants.ROUTE + "." + routeName + "." + MappingConstants.IS_HEADER_VALIDATION_ENABLED);
+                MappingConstants.ROUTE + "." + routeName + "." + MappingConstants.IS_HEADER_VALIDATION_ENABLED);
             if (isBlank(isHeaderValidationEnabled)) {
                 isHeaderValidationEnabled = Boolean.FALSE.toString();
             }
@@ -209,6 +220,13 @@ public class DataLoadRoute {
             routePropertiesList.add(index, properties);
             properties.setDeleteSql(environment.getProperty(MappingConstants.ROUTE + "."
                 + routeName + "." + MappingConstants.DELETE_SQL));
+            String parentFailureEnabled = environment.getProperty(MappingConstants.ROUTE + "."
+                + routeName + "." + MappingConstants.PARENT_FAILURE_ENABLED);
+            if (nonNull(parentFailureEnabled)) {
+                properties.setParentFailureEnabled(BooleanUtils.toBoolean(parentFailureEnabled));
+            }
+            properties.setParentFileName(environment.getProperty(MappingConstants.ROUTE + "."
+                + routeName + "." + MappingConstants.PARENT_NAME));
             index++;
         }
         return routePropertiesList;

--- a/src/main/java/uk/gov/hmcts/reform/data/ingestion/camel/route/beans/RouteProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/data/ingestion/camel/route/beans/RouteProperties.java
@@ -36,4 +36,8 @@ public class RouteProperties {
     String csvHeadersExpected;
 
     String isHeaderValidationEnabled;
+
+    String parentFileName;
+
+    boolean parentFailureEnabled;
 }

--- a/src/main/java/uk/gov/hmcts/reform/data/ingestion/camel/util/MappingConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/data/ingestion/camel/util/MappingConstants.java
@@ -72,4 +72,11 @@ public class MappingConstants {
     public static final String IS_HEADER_VALIDATION_ENABLED = "header-validation-enabled";
 
     public static final String COMA = ",";
+
+    public static final String PARENT_FAILURE_ENABLED = "parent-failure-enabled";
+
+    public static final String IS_PARENT_FAILED = "ISPARENTFAILED";
+
+    //parent-name
+    public static final String PARENT_NAME = "parent-name";
 }

--- a/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/DataIngestionLibraryRunnerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/DataIngestionLibraryRunnerTest.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.reform.data.ingestion.camel.service.AuditServiceImpl;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 public class DataIngestionLibraryRunnerTest {
@@ -35,7 +35,7 @@ public class DataIngestionLibraryRunnerTest {
 
     @BeforeEach
     public void setUp() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/processor/ArchivalBlobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/processor/ArchivalBlobServiceTest.java
@@ -48,7 +48,7 @@ public class ArchivalBlobServiceTest {
         setField(archivalBlobService, "producerTemplate", producerTemplate);
         doNothing().when(archivalRoute).archivalRoute(anyList());
         doNothing().when(producerTemplate).sendBody(any());
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/processor/ExceptionProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/processor/ExceptionProcessorTest.java
@@ -54,7 +54,7 @@ public class ExceptionProcessorTest extends CamelTestSupport {
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/processor/ParentStateCheckProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/processor/ParentStateCheckProcessorTest.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.data.ingestion.camel.processor;
+
+import lombok.SneakyThrows;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import uk.gov.hmcts.reform.data.ingestion.camel.route.beans.FileStatus;
+import uk.gov.hmcts.reform.data.ingestion.camel.route.beans.RouteProperties;
+import uk.gov.hmcts.reform.data.ingestion.camel.util.DataLoadUtil;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.data.ingestion.camel.helper.JrdTestSupport.createRoutePropertiesMock;
+import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.FAILURE;
+import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.ROUTE_DETAILS;
+
+
+public class ParentStateCheckProcessorTest {
+
+    Exchange exchangeMock = mock(Exchange.class);
+
+    CamelContext camelContext = spy(new DefaultCamelContext());
+
+    Message messageMock = mock(Message.class);
+
+    ParentStateCheckProcessor parentStateCheckProcessor = spy(new ParentStateCheckProcessor());
+
+    @BeforeEach
+    @SneakyThrows
+    public void setUp() {
+        when(exchangeMock.getContext()).thenReturn(camelContext);
+        when(exchangeMock.getIn()).thenReturn(messageMock);
+        when(exchangeMock.getMessage()).thenReturn(messageMock);
+        RouteProperties routeProperties = createRoutePropertiesMock();
+        routeProperties.setParentFailureEnabled(true);
+        routeProperties.setParentFileName("test");
+        when(messageMock.getHeader(ROUTE_DETAILS)).thenReturn(routeProperties);
+
+    }
+
+    @SneakyThrows
+    @Test
+    public void testProcessSetParentHeaderFailed() {
+        try (MockedStatic<DataLoadUtil> theMock = mockStatic(DataLoadUtil.class)) {
+            theMock.when(() -> DataLoadUtil.getFileDetails(any(), anyString()))
+                .thenReturn(FileStatus.builder()
+                    .auditStatus(FAILURE).build());
+            parentStateCheckProcessor.process(exchangeMock);
+            verify(parentStateCheckProcessor).process(exchangeMock);
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    public void testProcessSetParentHeaderTrue() {
+        parentStateCheckProcessor.process(exchangeMock);
+        verify(parentStateCheckProcessor).process(exchangeMock);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/service/AuditServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/service/AuditServiceImplTest.java
@@ -60,7 +60,7 @@ public class AuditServiceImplTest {
         setField(dataLoadAuditUnderTest, "invalidExceptionSql", "select * from appointment");
         setField(dataLoadAuditUnderTest, "archivalFileNames", files);
         //when(camelContext.getRegistry()).thenReturn(registry);
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/data/ingestion/camel/service/EmailServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.javamail.JavaMailSender;
 import uk.gov.hmcts.reform.data.ingestion.camel.exception.EmailFailureException;
@@ -23,7 +24,6 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,7 +48,7 @@ public class EmailServiceTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        initMocks(this);
+        MockitoAnnotations.openMocks(this);
         response.setBody("empty");
         response.setStatusCode(200);
         mockData();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-2908


### Change description ###
refactor: child routes skipping support for parent failure(RDCC-2908)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
